### PR TITLE
Added the Messaging connection string for the ma-rep MS deploy section

### DIFF
--- a/Sitecore 9.3.0/XP/nested/application-ma.json
+++ b/Sitecore 9.3.0/XP/nested/application-ma.json
@@ -266,6 +266,7 @@
           "IIS Web Application Name": "[variables('maRepWebAppNameTidy')]",
           "Database Server Name": "[variables('sqlServerFqdnTidy')]",
           "Marketing Automation Database Name": "[variables('maSqlDatabaseNameTidy')]",
+          "Messaging Connection String": "[listkeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.ServiceBus/namespaces/authorizationRules', variables('azureServiceBusNamespaceNameTidy'), parameters('azureServiceBusAccessKeyName')), variables('azureServiceBusVersion')).primaryConnectionString]",
           "Reference Data Database Name": "[variables('refDataSqlDatabaseNameTidy')]",
           "Reference Data Database Application User Name": "[parameters('xcRefDataSqlDatabaseUserName')]",
           "Reference Data Database Application User Password": "[parameters('xcRefDataSqlDatabasePassword')]",


### PR DESCRIPTION
Deployment of a fresh environment using the Sitecore Azure Toolkit 2.4 works when the Messaging connection string for the ma-rep application is added to the site's configuration